### PR TITLE
Add missing imports for clj.stacktrace and clj.string in useful.exception

### DIFF
--- a/src/useful/exception.clj
+++ b/src/useful/exception.clj
@@ -1,4 +1,6 @@
-(ns useful.exception)
+(ns useful.exception
+  (:use [clojure.string :only [trim split-lines]]
+        [clojure.stacktrace :only [print-cause-trace]]))
 
 (defmacro rescue
   "Evaluate form, returning error-form on any Exception."


### PR DESCRIPTION
Hello, 

useful.exception was missing a couple of imports.

And thanks for making this library.
