### PR TITLE
Functions for splitting at subsequences and computing sequence pre-/suffixes

### DIFF
--- a/src/useful/seq.clj
+++ b/src/useful/seq.clj
@@ -234,3 +234,24 @@
   "Returns the items before sub."
   [sub s]
   (first (split-at-subs sub s)))
+
+(defn prefixes
+  "Returns a lazy seq of prefixes of s.
+
+  Takes an optional argument :min-length (default: 1) to filter shorter
+  prefixes."
+  [s & {:keys [min-length] :or {min-length 1}}]
+  (lazy-seq
+   (let [[pre suff] (split-at min-length s)]
+     (if (seq suff)
+       (cons pre (prefixes s :min-length (inc min-length)))
+       (if (= (count pre) min-length)
+         (list pre))))))
+
+(defn suffixes
+  "Returns a lazy seq of suffixes of s.
+
+  Takes an optional argument :min-length (default: 1) to filter shorter
+  suffixes."
+  [s & {:keys [min-length] :or {min-length 1}}]
+  (map reverse (prefixes (reverse s) :min-length min-length)))

--- a/test/useful/seq_test.clj
+++ b/test/useful/seq_test.clj
@@ -138,3 +138,18 @@
   (is (= '(0) (take-to-subs '(1 2) (range))))
   (is (= '() (take-to-subs '(0 1) (range))))
   (is (= (range 10) (take-to-subs '(23 42) (range 10)))))
+
+(deftest test-prefixes
+  (is (= '() (prefixes '())))
+  (is (= '((0) (0 1) (0 1 2)) (prefixes (range 3))))
+  (is (= '((0) (0 1) (0 1 2)) (take 3 (prefixes (range)))))
+  (is (= '((0 1 2)) (prefixes (range 3) :min-length 3)))
+  (is (= '((0 1) (0 1 2)) (prefixes (range 3) :min-length 2)))
+  (is (= '() (prefixes (range 23) :min-length 42))))
+
+(deftest test-suffixes
+  (is (= '() (suffixes '())))
+  (is (= '((2) (1 2) (0 1 2)) (suffixes (range 3))))
+  (is (= '((0 1 2)) (suffixes (range 3) :min-length 3)))
+  (is (= '((1 2) (0 1 2)) (suffixes (range 3) :min-length 2)))
+  (is (= '() (suffixes (range 23) :min-length 42))))


### PR DESCRIPTION
These two commits introduce four functions, namely `split-at-subs`, `take-to-subs`, `prefixes` and `suffixes` to work with subsequences. I would be happy if they could be merged into useful as I find them quite, well, useful and think that they might be used by a wider audience. Please refer to the unit-tests for examples of their usage.
