### PR TITLE
Filter vals speedup

### DIFF
--- a/src/useful/map.clj
+++ b/src/useful/map.clj
@@ -186,11 +186,14 @@
   [pred m]
   (filter-keys-by-val (complement pred) m))
 
-(defn filter-vals
-  "Returns a map that only contains values where (pred value) returns true."
-  [m pred]
+(defn filter-vals [m pred]
   (when m
-    (select-keys m (filter-keys-by-val pred m))))
+    (persistent! (reduce (fn [m [k v]]
+                           (if (pred v)
+                             m
+                             (dissoc! m k)))
+                         (transient m)
+                         m))))
 
 (defn remove-vals
   "Returns a map that only contains values where (pred value) returns false."


### PR DESCRIPTION
I found that `useful.map/filter-vals` was a hotspot in an app I'm working on.  By using transients I was able to speed it up 3x.  I've included the relevant criterium benchmarking reports in the commit messages.
