### PR TITLE
Add =?

### DIFF
--- a/test/flatland/useful/fn_test.clj
+++ b/test/flatland/useful/fn_test.clj
@@ -79,3 +79,13 @@
 
 (deftest test-ignoring-nils
   (is (= 6 ((ignoring-nils +) 1 nil 2 nil nil 3))))
+
+(deftest test-=?
+  (let [objs [1 :x [2] "foo"]]
+    (doseq [i (range (count objs))
+            :let [x (objs i)
+                  f (=? x)]
+            j (range (count objs))
+            :let [y (objs j)]]
+      (is (= (boolean (f y))
+             (boolean (= i j)))))))


### PR DESCRIPTION
I added a function named `=?` which mirrors the EquivPred stuff that Rich added to clojure the other day. I ran a benchmark on some simple tasks using `=?` compared to plain `=`, and it's around 25% faster for the particular use case I tried. Test code:

``` clojure
(let [objs [1 :x [2] "foo"]]
  (bench
   (doseq [x objs
           :let [cmp (=? x)]
           y objs]
     (cmp y))))
```

Evaluation count : 52415460 in 60 samples of 873591 calls.
             Execution time mean : 1.148325 us
    Execution time std-deviation : 23.104390 ns
   Execution time lower quantile : 1.097617 us ( 2.5%)
   Execution time upper quantile : 1.181024 us (97.5%)

Found 14 outliers in 60 samples (23.3333 %)
    low-severe   3 (5.0000 %)
    low-mild     9 (15.0000 %)
    high-mild    2 (3.3333 %)
 Variance from outliers : 9.3567 % Variance is slightly inflated by outliers

``` clojure
(let [objs [1 :x [2] "foo"]]
  (bench
   (doseq [x objs
           y objs]
     (= x y))))
```

Evaluation count : 40467780 in 60 samples of 674463 calls.
             Execution time mean : 1.492065 us
    Execution time std-deviation : 12.754895 ns
   Execution time lower quantile : 1.476391 us ( 2.5%)
   Execution time upper quantile : 1.523519 us (97.5%)

Found 2 outliers in 60 samples (3.3333 %)
    low-severe   2 (3.3333 %)
 Variance from outliers : 1.6389 % Variance is slightly inflated by outliers
