### PR TITLE
Fix docstring for pluralize

### DIFF
--- a/src/flatland/useful/string.clj
+++ b/src/flatland/useful/string.clj
@@ -25,10 +25,10 @@
 (defn pluralize
   "Return a pluralized phrase, appending an s to the singular form if no plural is provided.
   For example:
-     (plural 5 \"month\") => \"5 months\"
-     (plural 1 \"month\") => \"1 month\"
-     (plural 1 \"radius\" \"radii\") => \"1 radius\"
-     (plural 9 \"radius\" \"radii\") => \"9 radii\""
+     (pluralize 5 \"month\") => \"5 months\"
+     (pluralize 1 \"month\") => \"1 month\"
+     (pluralize 1 \"radius\" \"radii\") => \"1 radius\"
+     (pluralize 9 \"radius\" \"radii\") => \"9 radii\""
   [num singular & [plural]]
   (str num " " (if (= 1 num) singular (or plural (str singular "s")))))
 


### PR DESCRIPTION
The function is named pluralize, not plural.
