### PR TITLE
Call 0 arity function when all arguments to ignoring-nil are nil

### DIFF
--- a/src/flatland/useful/fn.clj
+++ b/src/flatland/useful/fn.clj
@@ -123,7 +123,7 @@
            (f a)
            (f a b))))
     ([a b & more]
-       (when-let [items (seq (remove nil? (list* a b more)))]
+       (let [items (seq (remove nil? (list* a b more)))]
          (apply f items)))))
 
 (defn key-comparator

--- a/test/flatland/useful/fn_test.clj
+++ b/test/flatland/useful/fn_test.clj
@@ -78,7 +78,10 @@
   (is (= 5 (thrush 1 inc inc inc inc))))
 
 (deftest test-ignoring-nils
-  (is (= 6 ((ignoring-nils +) 1 nil 2 nil nil 3))))
+  (is (= 6 ((ignoring-nils +) 1 nil 2 nil nil 3)))
+  (is (= 0 ((ignoring-nils +) nil nil)))
+  (is (= 0 ((ignoring-nils +) nil nil nil)))
+  (is (= 0 ((ignoring-nils +) nil nil nil nil))))
 
 (deftest test-key-comparator
   (let [subtract-comparator-fn-breaks-on-this [2147483650 2147483651


### PR DESCRIPTION
Previously this would return nil if three or more arguments were
provided and all were nil.

The current behaviour looks like a bug, but changing this could
potentially be breaking to consumers. I couldn't see this function being
used in open source when searching with
[crossclj](https://crossclj.info/fun/flatland.useful.fn/ignoring-nils.html)

Fixes #38