### PR TITLE
Use java.util.Base64 instead of BASE64Encoder

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,8 +7,9 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/tools.macro "0.1.1"]
                  [org.clojure/tools.reader "0.7.2"]]
-  :aliases {"testall" ["with-profile" "1.6:1.7:1.8:1.9:1.10" "test"]}
-  :profiles {:1.10 {:dependencies [[org.clojure/clojure "1.10.0-RC3"]]}
+  :aliases {"testall" ["with-profile" "+1.6:+1.7:+1.8:+1.9:+1.10" "test"]}
+  :profiles {:dev {:dependencies [[org.clojure/test.check "0.10.0-alpha3"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.0-RC3"]]}
              :1.9  {}
              :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.7  {:dependencies [[org.clojure/clojure "1.7.0"]]}

--- a/src/flatland/useful/compress.clj
+++ b/src/flatland/useful/compress.clj
@@ -1,7 +1,8 @@
 (ns flatland.useful.compress
   (:import [java.util.zip DeflaterOutputStream InflaterInputStream]
            [java.io ByteArrayOutputStream ByteArrayInputStream]
-           [sun.misc BASE64Decoder BASE64Encoder]))
+           [sun.misc BASE64Decoder BASE64Encoder]
+           [java.util Base64]))
 
 (defn smash [^String str]
   (let [out (ByteArrayOutputStream.)]
@@ -15,3 +16,20 @@
   (let [bytes (-> (BASE64Decoder.) (.decodeBuffer str))
         in    (ByteArrayInputStream. bytes)]
     (slurp (InflaterInputStream. in))))
+
+
+
+
+(defn unsmash-new [^String s]
+  (let [bytes (.decode (Base64/getDecoder) (subs s 0 (dec (count s))))
+        in (ByteArrayInputStream. bytes)]
+    (slurp (InflaterInputStream. in))))
+
+(defn smash-new [^String s]
+  (let [out (ByteArrayOutputStream.)]
+    (doto (DeflaterOutputStream. out)
+      (.write (.getBytes s))
+      (.finish))
+    (-> (.encodeToString (Base64/getEncoder) (.toByteArray out))
+         (str (System/getProperty "line.separator")))))
+

--- a/test/flatland/useful/compress_test.clj
+++ b/test/flatland/useful/compress_test.clj
@@ -1,5 +1,9 @@
 (ns flatland.useful.compress-test
-  (:use clojure.test flatland.useful.compress))
+  (:use clojure.test
+        flatland.useful.compress)
+  (:require [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]))
 
 
 (deftest round-trip
@@ -7,3 +11,16 @@
 g2 sd35g4szdf sdf4 as89faw76fwfwf210
 "]
     (is (= s (unsmash (smash s))))))
+
+(deftest smash-test
+  (is (= "eJwDAAAAAAE=\n" (smash-new "")))
+  (is (= "eJxLBAAAYgBi\n" (smash-new "a"))))
+
+(deftest unsmash-test
+  (is (= "" (unsmash-new "eJwDAAAAAAE=\n")))
+  (is (= "a" (unsmash-new "eJxLBAAAYgBi\n"))))
+
+(defspec round-trip-gen
+  100
+  (prop/for-all [s gen/string]
+    (= s (unsmash-new (smash s)))))


### PR DESCRIPTION
For backwards/forwards compatibility between implementations, adds a
trailing newline to the string to match the behaviour of the sun.misc.BASE64Decoder.

This effectively sets the minimum JVM to Java 8, at least to use this
namespace.