### PR TITLE
Update Base64 to modern Java

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,11 +7,9 @@
   :dependencies [[org.clojure/clojure "1.8.0"  :scope "provided"]
                  [org.clojure/tools.macro "0.1.5"]
                  [org.clojure/tools.reader "1.3.2"]]
-  :aliases {"testall" ["with-profile" "1.6:1.7:1.8:1.9:1.10" "test"]}
+  :aliases {"testall" ["with-profile" ":1.8:1.9:1.10" "test"]}
 
-  :profiles {:provided {:dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]]}
-             :dev      {:dependencies [[org.clojure/clojure "1.10.1"]]}
-
+  :profiles {:dev      {:dependencies [[org.clojure/clojure "1.10.1"]]}
              :1.10     {:dependencies [[org.clojure/clojure "1.10.1"]]}
              :1.9      {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.8      {:dependencies [[org.clojure/clojure "1.8.0"]]}}

--- a/project.clj
+++ b/project.clj
@@ -1,20 +1,24 @@
 (defproject org.flatland/useful "0.11.7-SNAPSHOT"
   :description "A collection of generally-useful Clojure utility functions"
-  :license {:name "Eclipse Public License - v 1.0"
-            :url "http://www.eclipse.org/legal/epl-v10.html"
+  :license {:name         "Eclipse Public License - v 1.0"
+            :url          "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}
   :url "https://github.com/amalloy/useful"
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/tools.macro "0.1.1"]
-                 [org.clojure/tools.reader "0.7.2"]]
+  :dependencies [[org.clojure/clojure "1.8.0"  :scope "provided"]
+                 [org.clojure/tools.macro "0.1.5"]
+                 [org.clojure/tools.reader "1.3.2"]]
   :aliases {"testall" ["with-profile" "1.6:1.7:1.8:1.9:1.10" "test"]}
-  :profiles {:1.10 {:dependencies [[org.clojure/clojure "1.10.0-RC3"]]}
-             :1.9  {}
-             :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.7  {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :1.6  {:dependencies [[org.clojure/clojure "1.6.0"]]}}
+
+  :profiles {:provided {:dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]]}
+             :dev      {:dependencies [[org.clojure/clojure "1.10.1"]]}
+
+             :1.10     {:dependencies [[org.clojure/clojure "1.10.1"]]}
+             :1.9      {:dependencies [[org.clojure/clojure "1.9.0"]]}
+             :1.8      {:dependencies [[org.clojure/clojure "1.8.0"]]}}
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
-  :plugins [[codox "0.8.0"]]
-  :codox {:src-dir-uri "http://github.com/flatland/useful/blob/develop/"
+  :plugins [[codox "0.8.0"]
+            [lein-ancient "0.6.15"]]
+
+  :codox {:src-dir-uri               "http://github.com/flatland/useful/blob/develop/"
           :src-linenum-anchor-prefix "L"})

--- a/src/flatland/useful/compress.clj
+++ b/src/flatland/useful/compress.clj
@@ -1,17 +1,19 @@
 (ns flatland.useful.compress
-  (:import [java.util.zip DeflaterOutputStream InflaterInputStream]
-           [java.io ByteArrayOutputStream ByteArrayInputStream]
-           [sun.misc BASE64Decoder BASE64Encoder]))
+  (:import
+    [java.io ByteArrayOutputStream ByteArrayInputStream]
+    [java.util Base64]
+    [java.util.zip DeflaterOutputStream InflaterInputStream] ))
 
-(defn smash [^String str]
+(defn smash [str]
   (let [out (ByteArrayOutputStream.)]
     (doto (DeflaterOutputStream. out)
       (.write (.getBytes str))
       (.finish))
-    (-> (BASE64Encoder.)
-        (.encodeBuffer (.toByteArray out)))))
+    (-> (Base64/getEncoder)
+      (.encode (.toByteArray out)))))
 
-(defn unsmash [^String str]
-  (let [bytes (-> (BASE64Decoder.) (.decodeBuffer str))
+(defn unsmash [str]
+  (let [bytes (-> (Base64/getDecoder) (.decode str))
         in    (ByteArrayInputStream. bytes)]
     (slurp (InflaterInputStream. in))))
+

--- a/test/flatland/_bootstrap.clj
+++ b/test/flatland/_bootstrap.clj
@@ -1,0 +1,17 @@
+(ns flatland._bootstrap
+  (:require
+    [clojure.test :refer :all]
+    [clojure.string :as str] ))
+
+(defn print-versions []
+  (let [version-str (format "   Clojure %s    Java %s"
+                      (clojure-version) (System/getProperty "java.version"))
+        num-hyphen  (+ 6 (count version-str))
+        hyphens     (str/join (repeat num-hyphen \-)) ]
+    (newline)
+    (println hyphens)
+    (println version-str)
+    (println hyphens)))
+
+(deftest t-bootstrap-16
+  (print-versions))


### PR DESCRIPTION
Works with Clojure 1.8/1.10.1 and Java 8/12

---------------------------

```
lein test flatland._bootstrap

----------------------------------
   Clojure 1.10.1    Java 12
----------------------------------

lein test flatland.useful.bean-test

lein test flatland.useful.cli-test

lein test flatland.useful.compress-test

lein test flatland.useful.config-test

lein test flatland.useful.datatypes-test

lein test flatland.useful.debug-test

lein test flatland.useful.deftype-test

lein test flatland.useful.dispatch-test

lein test flatland.useful.exception-test

lein test flatland.useful.experimental-test

lein test flatland.useful.fn-test

lein test flatland.useful.io-test

lein test flatland.useful.java-test
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by flatland.useful.java$invoke_private to method java.util.Hashtable.rehash()
WARNING: Please consider reporting this to the maintainers of flatland.useful.java$invoke_private
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

lein test flatland.useful.macro-test

lein test flatland.useful.map-test

lein test flatland.useful.ns-test

lein test flatland.useful.parallel-test

lein test flatland.useful.seq-test

lein test flatland.useful.state-test

lein test flatland.useful.string-test

lein test flatland.useful.test-test

lein test flatland.useful.utils-test

Ran 143 tests containing 546 assertions.
0 failures, 0 errors.
lein test :all  18.45s user 0.47s system 302% cpu 6.247 total

```